### PR TITLE
Set the remember cookie

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.redgate.jira.auth</groupId>
     <artifactId>httpheader</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
 
     <organization>
         <name>Redgate</name>

--- a/src/main/java/com/redgate/jira/auth/httpheader/HttpHeaderAuthenticator.java
+++ b/src/main/java/com/redgate/jira/auth/httpheader/HttpHeaderAuthenticator.java
@@ -43,6 +43,9 @@ public class HttpHeaderAuthenticator extends com.atlassian.jira.security.login.J
         }
 
         this.authoriseUserAndEstablishSession(request, response, user);
+        // Set the remember me cookie to work around suspected "Bot Killer plugin" bug which ends up
+        // destroying sessions after 1h of inactivity rather than 5
+        this.getRememberMeService().addRememberMeCookie(request, response, username);
         this.getElevatedSecurityGuard().onSuccessfulLoginAttempt(request, username);
         return user;
     }


### PR DESCRIPTION
 to work around the 'Bot Killer plugin' destroying sessions after 1h of inactivity rather than the default 5h...

Suspect we're seeing this: https://community.atlassian.com/t5/Jira-questions/JIRA-session-timeout-set-to-1-hour-due-to-JIRA-bug-Okta-and-2FA/qaq-p/630382

By setting the cookie, JIRA will use it to recreated the session without the user being aware, provided that our SSO proxy let's the user through of course 😄 